### PR TITLE
fix: atomic nextTag() & use strconv.FormatUint()

### DIFF
--- a/client.go
+++ b/client.go
@@ -13,6 +13,7 @@ import (
 	"io"
 	"net"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/swoga/go-routeros/proto"
@@ -27,10 +28,14 @@ type Client struct {
 	w       proto.Writer
 	closing bool
 	async   bool
-	nextTag int64
+	lastTag atomic.Uint64
 	tags    map[string]sentenceProcessor
 	mu      sync.Mutex
 	timeout time.Duration
+}
+
+func (c *Client) nextTag() uint64 {
+	return c.lastTag.Add(1)
 }
 
 // NewClient returns a new Client over rwc. Login must be called.

--- a/listen.go
+++ b/listen.go
@@ -1,7 +1,7 @@
 package routeros
 
 import (
-	"fmt"
+	"strconv"
 
 	"github.com/swoga/go-routeros/proto"
 )
@@ -42,9 +42,8 @@ func (c *Client) ListenArgsQueue(sentence []string, queueSize int) (*ListenReply
 		c.Async()
 	}
 
-	c.nextTag++
 	l := &ListenReply{c: c}
-	l.tag = fmt.Sprintf("l%d", c.nextTag)
+	l.tag = "l" + strconv.FormatUint(c.nextTag(), 10)
 	l.reC = make(chan *proto.Sentence, queueSize)
 
 	c.w.BeginSentence()

--- a/run.go
+++ b/run.go
@@ -1,7 +1,7 @@
 package routeros
 
 import (
-	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -61,10 +61,9 @@ func (c *Client) endCommandSync() (*Reply, error) {
 }
 
 func (c *Client) endCommandAsync() (*asyncReply, error) {
-	c.nextTag++
 	a := &asyncReply{}
 	a.reC = make(chan *proto.Sentence)
-	a.tag = fmt.Sprintf("r%d", c.nextTag)
+	a.tag = "r" + strconv.FormatUint(c.nextTag(), 10)
 	c.w.WriteWord(".tag=" + a.tag)
 
 	c.mu.Lock()


### PR DESCRIPTION
Use atomic type to avoid race.

And `strconv.FormatUint()` should be a bit faster than `fmt.Sprintf()`

@swoga
Note that my [`main` branch](https://github.com/afriza/go-routeros/commits/main) includes both this atomic-tag (PR #5) and timeout-cleanup (PR #6).