### PR TITLE
fix: stop timeout timer immediately when unused

### DIFF
--- a/run.go
+++ b/run.go
@@ -40,12 +40,16 @@ func (c *Client) RunArgs(sentence []string) (*Reply, error) {
 
 readAllSentences:
 	for {
+		timeout, timer := newTimeoutTimer(c.timeout)
 		select {
 		case _, open := <-a.reC:
+			if timer != nil {
+				timer.Stop()
+			}
 			if !open {
 				break readAllSentences
 			}
-		case <-time.After(c.timeout):
+		case <-timeout:
 			return nil, errAsyncTimeout
 		}
 	}
@@ -79,4 +83,12 @@ func (c *Client) endCommandAsync() (*asyncReply, error) {
 	}
 	c.tags[a.tag] = a
 	return a, nil
+}
+
+func newTimeoutTimer(d time.Duration) (timeout <-chan time.Time, timer *time.Timer) {
+	if d > 0 {
+		timer = time.NewTimer(d)
+		timeout = timer.C
+	}
+	return
 }


### PR DESCRIPTION
`Timer`s created with `time.After()` are recovered only after it fires.
Therefore, it is not recommended to be used inside loops or when efficiency is a concern.

@swoga 
Note that my [`main` branch](https://github.com/afriza/go-routeros/commits/main) includes both this timeout-cleanup (PR #6) and atomic-tag (PR #5).