### PR TITLE
feat: Add new `!empty` sentence for RouterOS 7.18+

### DIFF
--- a/listen.go
+++ b/listen.go
@@ -81,7 +81,7 @@ func (l *ListenReply) processSentence(sen *proto.Sentence) (bool, error) {
 		return true, &DeviceError{sen}
 	case "!fatal":
 		return true, &DeviceError{sen}
-	case "":
+	case "", "!empty":
 		// API docs say that empty sentences should be ignored
 	default:
 		return true, &UnknownReplyError{sen}

--- a/reply.go
+++ b/reply.go
@@ -55,7 +55,7 @@ func (r *Reply) processSentence(sen *proto.Sentence) (bool, error) {
 		return true, nil
 	case "!trap", "!fatal":
 		return sen.Word == "!fatal", &DeviceError{sen}
-	case "":
+	case "", "!empty":
 		// API docs say that empty sentences should be ignored
 	default:
 		return true, &UnknownReplyError{sen}


### PR DESCRIPTION
Based on https://github.com/go-routeros/routeros/pull/29

fixes #19 